### PR TITLE
Add collapsible side menu to homepage

### DIFF
--- a/CMS.Web/Pages/Shared/_Layout.cshtml
+++ b/CMS.Web/Pages/Shared/_Layout.cshtml
@@ -12,6 +12,7 @@
     <header>
         <nav class="navbar navbar-expand-sm navbar-toggleable-sm navbar-light bg-white border-bottom box-shadow mb-3">
             <div class="container">
+                <button class="open-btn" onclick="toggleNav()">&#9776;</button> <!-- Toggle button -->
                 <a class="navbar-brand" asp-area="" asp-page="/Index">CMS.Web</a>
                 <button class="navbar-toggler" type="button" data-bs-toggle="collapse" data-bs-target=".navbar-collapse" aria-controls="navbarSupportedContent"
                         aria-expanded="false" aria-label="Toggle navigation">
@@ -33,7 +34,16 @@
             </div>
         </nav>
     </header>
-    <div class="container">
+    <div id="sideMenu" class="side-menu"> <!-- Initially closed by default due to site.css styles -->
+        <a href="javascript:void(0)" class="close-btn" onclick="toggleNav()">&times;</a>
+        <a asp-area="" asp-page="/Index">Home</a>
+        <a href="#">Products</a>
+        <a href="#">About Us</a>
+        <a asp-area="" asp-page="/Posts/Index">Posts</a>
+        <a asp-area="" asp-page="/Privacy">Privacy</a>
+    </div>
+
+    <div class="container" id="mainContent">
         <main role="main" class="pb-3">
             @RenderBody()
         </main>

--- a/CMS.Web/wwwroot/css/site.css
+++ b/CMS.Web/wwwroot/css/site.css
@@ -20,3 +20,99 @@ html {
 body {
   margin-bottom: 60px;
 }
+
+/* Styles for the side menu */
+.side-menu {
+    height: 100%;
+    width: 0; /* Initially hidden */
+    position: fixed;
+    z-index: 1000; /* Ensure it's above other content */
+    top: 0;
+    left: 0;
+    background-color: #f8f9fa; /* Light gray background */
+    overflow-x: hidden; /* Disable horizontal scroll */
+    padding-top: 56px; /* Adjust to match header height */
+    transition: 0.3s ease-in-out; /* Smooth transition for opening/closing */
+    border-right: 1px solid #dee2e6;
+}
+
+.side-menu.open {
+    width: 250px;
+}
+
+.side-menu a {
+    padding: 10px 15px;
+    text-decoration: none;
+    font-size: 18px;
+    color: #343a40; /* Dark gray text */
+    display: block;
+    transition: 0.2s ease-in-out;
+}
+
+.side-menu a:hover {
+    color: #007bff; /* Blue on hover */
+    background-color: #e9ecef; /* Light hover background for links */
+}
+
+/* Style for the close button inside the side menu */
+.side-menu .close-btn {
+    position: absolute;
+    top: 0px; /* Align with padding-top of menu */
+    right: 15px;
+    font-size: 36px;
+    line-height: 56px; /* Vertically center with header/padding */
+    color: #343a40;
+}
+.side-menu .close-btn:hover {
+    color: #0056b3; /* Darker blue on hover */
+}
+
+
+/* Style for the main content area */
+#mainContent {
+    transition: margin-left 0.3s ease-in-out;
+    padding: 15px; /* Add some padding to main content */
+}
+
+#mainContent.shifted {
+    margin-left: 250px;
+}
+
+/* Style for the toggle button (hamburger icon) */
+.open-btn {
+    font-size: 25px; /* Slightly larger icon */
+    cursor: pointer;
+    background-color: transparent; /* Make it transparent */
+    color: #343a40; /* Dark gray text */
+    padding: 5px 10px; /* Adjust padding */
+    border: none;
+    margin-right: 10px; /* Add some margin to separate from brand */
+}
+
+.open-btn:hover {
+    color: #007bff; /* Blue on hover */
+}
+
+/* Responsive adjustments */
+@media (max-width: 767.98px) {
+    .side-menu {
+        padding-top: 56px; /* Ensure padding is consistent with header */
+    }
+    #mainContent.shifted {
+        margin-left: 0; /* Don't shift content on small screens if menu overlays */
+    }
+    /* Optional: On small screens, you might want the menu to overlay content instead of pushing it.
+       If so, remove margin-left adjustments for #mainContent.shifted and ensure .side-menu.open has high z-index.
+       The current setup pushes content, which might be fine.
+    */
+}
+
+/* Adjustments for when the Bootstrap navbar collapses */
+@media (max-width: 575.98px) {
+    .navbar-brand {
+        margin-left: 5px; /* Add a bit of margin if open-btn is too close */
+    }
+     .open-btn {
+        margin-left: 0; /* No extra margin on very small screens */
+    }
+}

--- a/CMS.Web/wwwroot/js/site.js
+++ b/CMS.Web/wwwroot/js/site.js
@@ -2,3 +2,16 @@
 // for details on configuring this project to bundle and minify static web assets.
 
 // Write your JavaScript code.
+
+// JavaScript for toggling the side menu using class manipulation
+function toggleNav() {
+    var sideMenu = document.getElementById("sideMenu");
+    var mainContent = document.getElementById("mainContent");
+
+    if (sideMenu && mainContent) { // Ensure elements exist before trying to toggle classes
+        sideMenu.classList.toggle("open");
+        mainContent.classList.toggle("shifted");
+    } else {
+        console.error("Side menu or main content element not found.");
+    }
+}


### PR DESCRIPTION
This commit introduces a collapsible side menu to the main layout.

Key features:
- A side menu is added to the left of the page.
- The menu can be toggled (opened/closed) using a hamburger button in the header and a close button within the menu.
- On larger screens, the main content area shifts to the right to accommodate the open menu.
- On smaller screens, the menu overlays the content.
- Placeholder menu items have been added.
- Styles for the menu and its behavior are in `site.css`.
- JavaScript logic for toggling is in `site.js`.

The changes were made to `CMS.Web/Pages/Shared/_Layout.cshtml`, `CMS.Web/wwwroot/css/site.css`, and `CMS.Web/wwwroot/js/site.js`. I tested the implementation by simulating user interaction and reviewing the code to ensure responsiveness and correct functionality across different screen sizes.