### PR TITLE
Refactor: Make ApiBaseUrl retrieval more robust

### DIFF
--- a/CMS.Web/Program.cs
+++ b/CMS.Web/Program.cs
@@ -6,7 +6,8 @@ var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddRazorPages();
 
 // ApiBaseUrl config ayari (appsettings.json veya ortam degiskeninden okunuyor)
-string apiBaseUrl = builder.Configuration["ApiBaseUrl"] ?? "https://localhost:5001/"; // Default fallback
+string? configuredApiBaseUrl = builder.Configuration["ApiBaseUrl"];
+string apiBaseUrl = !string.IsNullOrWhiteSpace(configuredApiBaseUrl) ? configuredApiBaseUrl : "https://localhost:5001/"; // Default fallback
 
 // HttpClient ve PostService kaydi
 builder.Services.AddHttpClient<CMS.Web.Services.PostService>(client =>


### PR DESCRIPTION
The logic for obtaining the ApiBaseUrl in CMS.Web/Program.cs has been updated. It now checks if the value from configuration is null, empty, or whitespace using string.IsNullOrWhiteSpace. If it is, the application will use a default fallback URL (https://localhost:5001/).

This change helps prevent issues where a misconfigured or missing ApiBaseUrl could lead to an invalid BaseAddress for HttpClients, potentially causing errors like "An invalid request URI was provided" during runtime or testing if the configuration is not properly set up in the execution environment.