### PR TITLE
I've improved the API error handling for database operations.

### DIFF
--- a/CMS/Controllers/CompaniesController.cs
+++ b/CMS/Controllers/CompaniesController.cs
@@ -25,7 +25,16 @@ namespace CMS.Controllers
         [HttpGet]
         public async Task<ActionResult<IEnumerable<Company>>> GetCompanies()
         {
-            return await _context.Companies.ToListAsync();
+            try
+            {
+                return await _context.Companies.ToListAsync();
+            }
+            catch (Exception ex) // Catching a general Exception for now. Consider NpgsqlException for more specificity.
+            {
+                // Log the exception (not implemented here, but good practice)
+                // logger.LogError(ex, "An error occurred while fetching companies.");
+                return StatusCode(StatusCodes.Status500InternalServerError, new { message = "An error occurred while fetching companies.", details = ex.Message });
+            }
         }
 
         // GET: api/Companies/5
@@ -78,10 +87,19 @@ namespace CMS.Controllers
         [HttpPost]
         public async Task<ActionResult<Company>> CreateCompany(Company company)
         {
-            _context.Companies.Add(company);
-            await _context.SaveChangesAsync();
+            try
+            {
+                _context.Companies.Add(company);
+                await _context.SaveChangesAsync();
 
-            return CreatedAtAction("GetCompany", new { id = company.Id }, company);
+                return CreatedAtAction(nameof(GetCompany), new { id = company.Id }, company);
+            }
+            catch (Exception ex) // Catching a general Exception for now. Consider DbUpdateException or NpgsqlException.
+            {
+                // Log the exception (not implemented here, but good practice)
+                // logger.LogError(ex, "An error occurred while creating a company.");
+                return StatusCode(StatusCodes.Status500InternalServerError, new { message = "An error occurred while creating the company.", details = ex.Message });
+            }
         }
 
         // DELETE: api/Companies/5


### PR DESCRIPTION
I added try-catch blocks to the CompaniesController actions (GetCompanies and CreateCompany) to handle potential exceptions during database interactions.

If an exception occurs, the API will now return a 500 Internal Server Error with a JSON body containing a message and exception details like this: `{ "message": "An error occurred...", "details": "Exception message" }`

This prevents the API from returning non-JSON responses (like HTML error pages) when database issues occur, which was causing a `System.InvalidOperationException` in your client-side `CompanyService`.

Your client will now receive an `HttpRequestException` if the API returns a 500, allowing for more specific error handling on the client side.

Please note: This change addresses the symptom of the client-side parsing error. You will still need to address any underlying database connectivity or state issues in your deployment environment by ensuring the connection string in `CMS/appsettings.json` is correct and the database is accessible and properly initialized.